### PR TITLE
Add Telegram trend auto-publisher with Docker scheduling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.gitignore
+__pycache__/
+*.py[cod]
+venv/
+env/
+.env
+media/
+data/
+logs/
+*.sqlite
+*.sqlite3
+*.db
+news.sql
+README.md
+docs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## Unreleased
+
+### Added
+- Trend auto-publisher (`feat/trend-publisher`): fetches rising posts for each
+  subreddit in `TREND_SUBREDDITS` via public Atom feeds (no OAuth needed),
+  picks the best not-yet-published post that has an image, and sends
+  photo + caption (title + `r/<subreddit>` link) to a Telegram channel.
+  - `app/trend_watcher.py` — RSS rising reader with rate-limit backoff.
+  - `app/telegram_publisher.py` — Telegram photo posting with upload fallback.
+  - `app/published_store.py` — SQLite store of published Reddit post ids for
+    deduplication (records the Telegram `message_id` of each post).
+  - `app/publish_trends.py` — orchestrator; one post per tracked subreddit per
+    run, so two subreddits on a twice-daily schedule means four posts per day.
+  - `app/trend_scheduler.py` — APScheduler cron runner driven by `PUBLISH_TIMES`
+    (default `09:00,21:00` UTC).
+  - `tools/backfill_published.py` — records an already-posted meme so it is
+    never reposted.
+- Docker packaging (`feat/trend-publisher`): `Dockerfile` and `docker-compose.yml`
+  to run the scheduler unattended with a mounted dedup store.
+- New environment variables documented in `env.example`: `TELEGRAM_TOKEN`,
+  `TELEGRAM_CHANNEL_ID`, `TREND_SUBREDDITS`, `PUBLISH_TIMES`, `PUBLISHED_DB`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,12 @@
   to run the scheduler unattended with a mounted dedup store.
 - New environment variables documented in `env.example`: `TELEGRAM_TOKEN`,
   `TELEGRAM_CHANNEL_ID`, `TREND_SUBREDDITS`, `PUBLISH_TIMES`, `PUBLISHED_DB`.
+- `.dockerignore` to keep the image small (excludes `.git`, caches, media,
+  local databases).
+
+### Changed
+- `README.md` rewritten: a banner at the top links the live Telegram channel
+  ([t.me/humorfromyumi](https://t.me/humorfromyumi)) and the trend publisher is
+  documented as a first-class feature alongside the sync engine.
+- `tools/backfill_published.py` now loads `.env` so it writes to the same
+  `PUBLISHED_DB` the publisher reads.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
   local databases).
 
 ### Changed
+- Captions no longer carry a decorative leading emoji — just the bold title and
+  the `r/<subreddit>` link.
 - `README.md` rewritten: a banner at the top links the live Telegram channel
   ([t.me/humorfromyumi](https://t.me/humorfromyumi)) and the trend publisher is
   documented as a first-class feature alongside the sync engine.
@@ -39,6 +41,9 @@
 - Default `TREND_SUBREDDITS` in `env.example` now includes `linuxmemes`.
 
 ### Added (continued)
+- Score threshold: only posts with a score of at least `MIN_SCORE` (default
+  1000) are published. Scores are read from the old.reddit rising HTML
+  (`data-score`), since the Atom feed carries none — `trend_watcher.rising_scores`.
 - Gallery posts are published as a single Telegram **album** (`sendMediaGroup`)
   instead of one image. Gallery images are enumerated from the old.reddit HTML
   (`id="media-tile-<post>-<media>"`, reachable without OAuth) and upgraded to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,13 @@
   140px `preview.redd.it` thumbnails (e.g. gallery posts) to the original
   `i.redd.it` file and skips posts with no full-size image, so the channel never
   shows a tiny thumbnail.
+- `PUBLISHED_DB` relative paths resolve against the repo root, so the publisher,
+  scheduler and tools share one dedup store regardless of working directory.
+- Default `TREND_SUBREDDITS` in `env.example` now includes `linuxmemes`.
+
+### Added (continued)
+- Gallery posts are published as a single Telegram **album** (`sendMediaGroup`)
+  instead of one image. Gallery images are enumerated from the old.reddit HTML
+  (`id="media-tile-<post>-<media>"`, reachable without OAuth) and upgraded to
+  full-resolution `i.redd.it` URLs. `app/telegram_publisher.py` gains
+  `send_media_group`; `app/trend_watcher.py` gains `gallery_image_urls`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,7 @@
   documented as a first-class feature alongside the sync engine.
 - `tools/backfill_published.py` now loads `.env` so it writes to the same
   `PUBLISHED_DB` the publisher reads.
+- `trend_watcher.extract_image` now returns full-resolution images: it upgrades
+  140px `preview.redd.it` thumbnails (e.g. gallery posts) to the original
+  `i.redd.it` file and skips posts with no full-size image, so the channel never
+  shows a tiny thumbnail.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+# Runs the trend publisher on a daily schedule (see PUBLISH_TIMES).
+CMD ["python", "app/trend_scheduler.py"]

--- a/README.md
+++ b/README.md
@@ -1,225 +1,163 @@
 # Reddit Sync
 
-A modern Python application for monitoring Reddit threads, downloading media content, and storing everything in a local SQLite database. Built with asynchronous architecture and intelligent scheduling for optimal performance and scalability.
+> 🤖 **This project powers a live Telegram channel** — twice a day it posts the
+> best rising memes from tracked subreddits.
+> **Follow it here → [t.me/humorfromyumi](https://t.me/humorfromyumi)**
 
-## ✨ Features
+A Python application that watches Reddit, publishes trending posts to a Telegram
+channel, and (optionally) archives threads and their media into a local SQLite
+database.
 
-- **Automated Scheduling**: Background scheduler with configurable intervals for continuous monitoring
-- **Thread Monitoring**: Automatically tracks specified Reddit threads and subreddits
-- **Enhanced Metrics**: Collects upvotes, comment counts, and engagement statistics
-- **Media Download**: Downloads images, videos, and other media content from posts
-- **SQLite Storage**: Stores all data in a structured SQLite database with SQLAlchemy ORM
-- **Concurrent Processing**: Supports concurrent media downloads with configurable limits
-- **OAuth2 Authentication**: Secure Reddit API access using refresh tokens
-- **Web Interface**: Modern web interface for browsing downloaded content with metrics
-- **Error Handling**: Robust error handling with exponential backoff retry logic
-- **Content Filtering**: Intelligent duplicate detection and content validation
+There are two independent parts, and you can run either on its own:
 
-## 🚀 Quick Start
+1. **Trend auto-publisher** — the piece that feeds the Telegram channel. Reads
+   rising posts from public Atom feeds (no OAuth), picks the best not-yet-posted
+   item with an image from each tracked subreddit, and posts photo + caption to
+   the channel on a schedule. **No Reddit API credentials required.**
+2. **Sync engine** — the original archiver: OAuth2 Reddit client, background
+   scheduler, media downloader, SQLAlchemy storage and a Flask browser UI.
+
+---
+
+## 📣 Trend auto-publisher (Telegram channel)
+
+### How it works
+
+- Fetches `/r/<subreddit>/rising.rss` for every subreddit in `TREND_SUBREDDITS`.
+  Reddit's JSON API rejects datacenter IPs, but the Atom feeds stay open, so the
+  publisher needs **no OAuth** — only a Telegram bot token.
+- "Best trending" = the order Reddit itself assigns to rising posts. The first
+  post that has an image and has not been published yet is chosen.
+- Posts **photo + caption** (title + `r/<subreddit>` link) to the channel.
+- A SQLite store (`published.sqlite`) remembers every published post id and its
+  Telegram `message_id`, so nothing is ever posted twice.
+- One post per tracked subreddit per run. With the default twice-a-day schedule,
+  **two subreddits ⇒ four posts per day**.
+
+### Configuration
+
+Add these to your `.env` (see `env.example`):
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TELEGRAM_TOKEN` | Bot token from @BotFather | *Required* |
+| `TELEGRAM_CHANNEL_ID` | Target channel id (e.g. `-1001234567890`) | *Required* |
+| `TREND_SUBREDDITS` | Comma-separated subreddits to watch | `ProgrammerHumor` |
+| `PUBLISH_TIMES` | Comma-separated `HH:MM` slots in UTC | `09:00,21:00` |
+| `PUBLISHED_DB` | Path to the dedup SQLite store | `./data/published.sqlite` |
+
+### Running
+
+```bash
+# One-off run: posts one meme per tracked subreddit
+python app/publish_trends.py
+
+# Preview only — select and log candidates without posting
+python app/publish_trends.py --dry-run
+
+# Run the scheduler in the foreground (posts at PUBLISH_TIMES)
+python app/trend_scheduler.py
+
+# Record an already-posted meme so it is never reposted
+python tools/backfill_published.py
+```
+
+### Docker (recommended for the channel)
+
+The container runs the scheduler and keeps the dedup store on a mounted volume:
+
+```bash
+docker compose up --build -d
+docker compose logs -f
+```
+
+---
+
+## 🗄️ Sync engine (optional archiver)
 
 ### Prerequisites
 
 - Python 3.11 or higher
-- Reddit API credentials (client ID and secret)
+- Reddit API credentials (client id and secret) — only for the sync engine
 
 ### Installation
 
-1. **Clone the repository**:
-   ```bash
-   git clone https://github.com/yourusername/RedditSync.git
-   cd RedditSync
-   ```
+```bash
+git clone https://github.com/yumiaura/RedditSync.git
+cd RedditSync
 
-2. **Create and activate virtual environment**:
-   ```bash
-   python -m venv venv
-   source venv/bin/activate  # On Windows: venv\Scripts\activate
-   ```
-
-3. **Install dependencies**:
-   ```bash
-   pip install -r requirements.txt
-   ```
-
-4. **Set up Reddit API credentials**:
-   ```bash
-   # Run the interactive token setup script
-   python tools/1_get_refresh_token.py --save
-   
-   # Verify your environment configuration
-   python tools/2_check_env.py
-   ```
-
-5. **Database migration (if upgrading from older version)**:
-   ```bash
-   # If you have an existing database, migrate it to the new schema
-   python tools/migrate_add_metrics.py
-   
-   # Test the scheduler implementation (optional)
-   python tools/test_scheduler.py
-   ```
-
-### Configuration
-
-Create a `.env` file in the project root based on `env.example`:
-
-```env
-# Required Reddit API settings
-REDDIT_CLIENT_ID=your_client_id_here
-REDDIT_CLIENT_SECRET=your_client_secret_here
-REDDIT_USER_AGENT=python:redditsync:v1.0 (by /u/yourusername)
-REDDIT_REFRESH_TOKEN=your_refresh_token_here
-
-# Optional configuration (with defaults)
-DB_PATH=db.sqlite
-MEDIA_DIR=media
-MAX_MEDIA_SIZE=52428800  # 50MB
-MAX_CONCURRENT_DOWNLOADS=5
-REDIRECT_PORT=8000
+python -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+pip install -r requirements.txt
 ```
 
-### Running the Application
+Set up Reddit API credentials:
 
 ```bash
-# Run the main sync application with scheduler
+# Interactive token setup
+python tools/1_get_refresh_token.py --save
+
+# Verify the environment configuration
+python tools/2_check_env.py
+```
+
+### Running
+
+```bash
+# Sync application with background scheduler
 python app/main.py
 
-# Or run the web interface (optional)
+# Web interface (optional)
 cd web && python app.py
 ```
 
-## 📅 Scheduler Configuration
+The sync engine uses **SQLAlchemy 2.0** (async, via `aiosqlite`) over three
+tables — `subscriptions`, `news`, `media` — with a background scheduler that
+performs an initial sync shortly after launch and a regular sync every two
+minutes.
 
-Reddit Sync runs with an intelligent background scheduler:
+---
 
-- **Initial Sync**: Starts 10 seconds after application launch
-- **Regular Sync**: Every 2 minutes, processes up to 5 new posts
-- **Automatic Database Setup**: Creates tables automatically on first run
-- **Metrics Update**: Automatically updates scores and comment counts for existing posts
-
-The scheduler prevents overlapping tasks and includes rate limiting to respect Reddit's API guidelines.
-
-## 📁 Project Structure
+## 📁 Project structure
 
 ```
 RedditSync/
-├── app/                      # Core application modules
-│   ├── __init__.py          # Package initialization
-│   ├── main.py              # Application entry point with scheduler
-│   ├── config.py            # Configuration management
-│   ├── db.py                # Database operations (SQLAlchemy ORM)
-│   ├── models.py            # Database models (SQLAlchemy)
-│   ├── reddit_client.py     # Reddit API client
-│   ├── media_downloader.py  # Media download functionality
-│   ├── sync_worker.py       # Synchronization orchestration
-│   └── utils.py             # Utility functions
+├── app/
+│   ├── main.py               # Sync-engine entry point (scheduler)
+│   ├── config.py             # Configuration for the sync engine
+│   ├── db.py                 # SQLAlchemy database operations
+│   ├── models.py             # SQLAlchemy models
+│   ├── reddit_client.py      # OAuth2 Reddit client (praw)
+│   ├── media_downloader.py   # Media download
+│   ├── sync_worker.py        # Sync orchestration
+│   ├── utils.py              # Utilities
+│   ├── trend_watcher.py      # Rising RSS reader (no OAuth)
+│   ├── telegram_publisher.py # Telegram photo posting
+│   ├── published_store.py    # SQLite dedup store
+│   ├── publish_trends.py     # Trend publisher orchestrator
+│   └── trend_scheduler.py    # Twice-daily scheduler for the publisher
+├── tools/
+│   ├── 1_get_refresh_token.py
+│   ├── 2_check_env.py
+│   └── backfill_published.py # Mark an already-posted meme as published
+├── web/                      # Flask browser UI (optional)
 ├── docs/                     # Documentation
-│   ├── spec.md              # Technical specification
-│   ├── get_token.md         # OAuth2 setup guide
-│   └── CODE_STYLE_EN.md     # Code style guidelines
-├── tools/                    # Utility scripts
-│   ├── 1_get_refresh_token.py  # OAuth2 token generator
-│   ├── 2_check_env.py          # Environment validator
-├── web/                      # Web interface (optional)
-│   ├── app.py               # Flask web application
-│   └── templates/           # HTML templates
-├── media/                    # Downloaded media files (created automatically)
-├── requirements.txt          # Python dependencies
-├── env.example              # Environment template
-└── README.md               # This file
+├── Dockerfile
+├── docker-compose.yml
+├── env.example
+├── requirements.txt
+└── CHANGELOG.md
 ```
 
-## 🗄️ Database Technology
+## 🛡️ Error handling & resilience
 
-The application uses **SQLAlchemy 2.0** with async support as the ORM (Object-Relational Mapping) layer:
-
-- **Database Engine**: SQLite with aiosqlite for async operations
-- **ORM**: SQLAlchemy 2.0 with modern async/await syntax
-- **Models**: Fully typed SQLAlchemy models with relationships
-- **Migrations**: Built-in migration tool for upgrading from raw SQL
-
-### Database Schema
-
-The application uses three main tables:
-
-- **`subscriptions`**: List of monitored Reddit threads/subreddits
-- **`news`**: Posts and comments with metadata and content  
-- **`media`**: Downloaded media files with metadata and references
-
-The ORM models provide:
-- **Type safety** with Python type hints
-- **Relationship mapping** between tables
-- **Automatic query generation** and optimization
-- **Connection pooling** and session management
-
-## ⚙️ Configuration Options
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `REDDIT_CLIENT_ID` | Reddit API client ID | *Required* |
-| `REDDIT_CLIENT_SECRET` | Reddit API client secret | *Required* |
-| `REDDIT_USER_AGENT` | User agent string for API requests | *Required* |
-| `REDDIT_REFRESH_TOKEN` | OAuth2 refresh token | *Required* |
-| `DB_PATH` | SQLite database file path | `db.sqlite` |
-| `MEDIA_DIR` | Directory for downloaded media | `media` |
-| `MAX_MEDIA_SIZE` | Maximum file size for downloads (bytes) | `52428800` (50MB) |
-| `MAX_CONCURRENT_DOWNLOADS` | Concurrent download limit | `5` |
-| `REDIRECT_PORT` | Port for OAuth2 redirect | `8000` |
-
-## 🛡️ Error Handling & Resilience
-
-- **Network errors**: Automatic retry with exponential backoff
-- **Rate limiting**: Respects Reddit API rate limits
-- **Large files**: Configurable size limits to prevent storage issues
-- **Duplicate detection**: Prevents duplicate downloads and storage
-- **Logging**: Comprehensive logging for debugging and monitoring
-
-## 🔧 Development
-
-### Code Style
-
-This project follows **PEP 8** standards with a **99-character line limit**. See `docs/CODE_STYLE_EN.md` for detailed guidelines.
-
-### Running Tests
-
-```bash
-# Install development dependencies
-pip install -r requirements-dev.txt
-
-# Run tests
-python -m pytest
-
-# Run with coverage
-python -m pytest --cov=app
-```
-
-### Contributing
-
-1. Fork the repository
-2. Create a feature branch
-3. Follow the code style guidelines
-4. Add tests for new functionality
-5. Submit a pull request
+- Rising feeds are rate-limited by Reddit; the watcher backs off and retries on
+  HTTP 429, and paces requests between subreddits.
+- Telegram posting falls back to uploading the image bytes if Telegram cannot
+  fetch the URL itself.
+- The dedup store guarantees a post is never sent to the channel twice.
+- Comprehensive logging (timestamp, level, logger name) for debugging.
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the LICENSE file for details.
-
-## 🤝 Support
-
-- **Documentation**: Check the `docs/` directory for detailed guides
-- **Issues**: Report bugs and feature requests via GitHub Issues
-- **Reddit API**: Refer to [Reddit API Documentation](https://www.reddit.com/dev/api/) for API-related questions
-
-## 🎯 Roadmap
-
-- [x] **SQLAlchemy ORM integration** 
-- [x] **Background scheduler with automated tasks**
-- [x] **Enhanced metrics collection (scores, comments)**
-- [ ] Notifications for new content
-- [ ] Advanced content filtering and categorization
-- [ ] Multi-subreddit batch operations
-- [ ] Export functionality (JSON, CSV)
-- [ ] Docker containerization
-- [ ] RESTful API for external integrations
-- [ ] Database performance optimizations and indexing
+This project is licensed under the MIT License — see the LICENSE file for details.

--- a/README.md
+++ b/README.md
@@ -27,12 +27,14 @@ There are two independent parts, and you can run either on its own:
   Reddit's JSON API rejects datacenter IPs, but the Atom feeds stay open, so the
   publisher needs **no OAuth** — only a Telegram bot token.
 - "Best trending" = the order Reddit itself assigns to rising posts. The first
-  post that has an image and has not been published yet is chosen.
+  post that has an image, a score of at least `MIN_SCORE`, and has not been
+  published yet is chosen (scores come from the old.reddit HTML listing).
 - Posts **photo + caption** (title + `r/<subreddit>` link) to the channel.
+  Gallery posts go out as a single **album** with every image at full resolution.
 - A SQLite store (`published.sqlite`) remembers every published post id and its
   Telegram `message_id`, so nothing is ever posted twice.
-- One post per tracked subreddit per run. With the default twice-a-day schedule,
-  **two subreddits ⇒ four posts per day**.
+- One post per tracked subreddit per run. With three subreddits on the default
+  twice-a-day schedule, that's up to **six posts per day**.
 
 ### Configuration
 
@@ -43,6 +45,7 @@ Add these to your `.env` (see `env.example`):
 | `TELEGRAM_TOKEN` | Bot token from @BotFather | *Required* |
 | `TELEGRAM_CHANNEL_ID` | Target channel id (e.g. `-1001234567890`) | *Required* |
 | `TREND_SUBREDDITS` | Comma-separated subreddits to watch | `ProgrammerHumor` |
+| `MIN_SCORE` | Only publish posts with at least this score | `1000` |
 | `PUBLISH_TIMES` | Comma-separated `HH:MM` slots in UTC | `09:00,21:00` |
 | `PUBLISHED_DB` | Path to the dedup SQLite store | `./data/published.sqlite` |
 

--- a/app/publish_trends.py
+++ b/app/publish_trends.py
@@ -1,0 +1,96 @@
+"""Publish the best unsent rising post from each tracked subreddit.
+
+One run posts at most one photo per subreddit in TREND_SUBREDDITS, so two
+tracked subreddits plus a twice-daily schedule yields four posts per day.
+"""
+import argparse
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import published_store
+import telegram_publisher
+import trend_watcher
+
+logger = logging.getLogger("trend_publisher")
+DEFAULT_SUBREDDITS = "ProgrammerHumor"
+RATE_LIMIT_PAUSE = 30
+
+
+def tracked_subreddits():
+    raw = os.getenv("TREND_SUBREDDITS", DEFAULT_SUBREDDITS)
+    return [name.strip() for name in raw.split(",") if name.strip()]
+
+
+def pick_unsent(connection, candidates):
+    for candidate in candidates:
+        if not candidate["reddit_id"] or not candidate["image_url"]:
+            continue
+        if published_store.is_published(connection, candidate["reddit_id"]):
+            continue
+        return candidate
+    return None
+
+
+def publish_once(dry_run=False):
+    load_dotenv()
+    token = os.getenv("TELEGRAM_TOKEN")
+    chat_id = os.getenv("TELEGRAM_CHANNEL_ID")
+    if not token or not chat_id:
+        raise SystemExit("TELEGRAM_TOKEN and TELEGRAM_CHANNEL_ID are required")
+
+    connection = published_store.open_store()
+    published = []
+    try:
+        for position, subreddit in enumerate(tracked_subreddits()):
+            if position:
+                time.sleep(RATE_LIMIT_PAUSE)  # respect Reddit's RSS rate limit
+            try:
+                candidates = trend_watcher.fetch_rising(subreddit)
+            except Exception as error:
+                logger.error("r/%s: could not fetch rising: %s", subreddit, error)
+                continue
+            choice = pick_unsent(connection, candidates)
+            if not choice:
+                logger.info("r/%s: no fresh post with an image to publish",
+                            subreddit)
+                continue
+            caption = telegram_publisher.build_caption(
+                choice["title"], subreddit, choice["permalink"])
+            if dry_run:
+                logger.info("r/%s: would publish '%s' (%s)",
+                            subreddit, choice["title"], choice["reddit_id"])
+                continue
+            result = telegram_publisher.send_photo(
+                token, chat_id, choice["image_url"], caption)
+            message_id = result["message_id"]
+            published_store.mark_published(
+                connection, choice["reddit_id"], subreddit,
+                choice["title"], choice["permalink"], message_id)
+            logger.info("r/%s: published '%s' as message_id=%s",
+                        subreddit, choice["title"], message_id)
+            published.append((subreddit, choice["title"], message_id))
+    finally:
+        connection.close()
+    return published
+
+
+def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    parser = argparse.ArgumentParser(description="Publish trending Reddit memes")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="select and log candidates without posting")
+    arguments = parser.parse_args()
+    publish_once(dry_run=arguments.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/app/publish_trends.py
+++ b/app/publish_trends.py
@@ -63,12 +63,23 @@ def publish_once(dry_run=False):
                 continue
             caption = telegram_publisher.build_caption(
                 choice["title"], subreddit, choice["permalink"])
+            images = [choice["image_url"]]
+            if choice.get("is_gallery"):
+                gallery = trend_watcher.gallery_image_urls(
+                    choice["permalink"], choice["reddit_id"])
+                if len(gallery) > 1:
+                    images = gallery
             if dry_run:
-                logger.info("r/%s: would publish '%s' (%s)",
-                            subreddit, choice["title"], choice["reddit_id"])
+                logger.info("r/%s: would publish '%s' (%s), %d image(s)",
+                            subreddit, choice["title"], choice["reddit_id"],
+                            len(images))
                 continue
-            result = telegram_publisher.send_photo(
-                token, chat_id, choice["image_url"], caption)
+            if len(images) > 1:
+                result = telegram_publisher.send_media_group(
+                    token, chat_id, images, caption)
+            else:
+                result = telegram_publisher.send_photo(
+                    token, chat_id, images[0], caption)
             message_id = result["message_id"]
             published_store.mark_published(
                 connection, choice["reddit_id"], subreddit,

--- a/app/publish_trends.py
+++ b/app/publish_trends.py
@@ -20,6 +20,7 @@ import trend_watcher
 
 logger = logging.getLogger("trend_publisher")
 DEFAULT_SUBREDDITS = "ProgrammerHumor"
+DEFAULT_MIN_SCORE = 1000
 RATE_LIMIT_PAUSE = 30
 
 
@@ -28,9 +29,15 @@ def tracked_subreddits():
     return [name.strip() for name in raw.split(",") if name.strip()]
 
 
-def pick_unsent(connection, candidates):
+def min_score():
+    return int(os.getenv("MIN_SCORE", DEFAULT_MIN_SCORE))
+
+
+def pick_unsent(connection, candidates, scores, threshold):
     for candidate in candidates:
         if not candidate["reddit_id"] or not candidate["image_url"]:
+            continue
+        if scores.get(candidate["reddit_id"], 0) < threshold:
             continue
         if published_store.is_published(connection, candidate["reddit_id"]):
             continue
@@ -51,16 +58,19 @@ def publish_once(dry_run=False):
         for position, subreddit in enumerate(tracked_subreddits()):
             if position:
                 time.sleep(RATE_LIMIT_PAUSE)  # respect Reddit's RSS rate limit
+            threshold = min_score()
             try:
                 candidates = trend_watcher.fetch_rising(subreddit)
+                scores = trend_watcher.rising_scores(subreddit)
             except Exception as error:
                 logger.error("r/%s: could not fetch rising: %s", subreddit, error)
                 continue
-            choice = pick_unsent(connection, candidates)
+            choice = pick_unsent(connection, candidates, scores, threshold)
             if not choice:
-                logger.info("r/%s: no fresh post with an image to publish",
-                            subreddit)
+                logger.info("r/%s: no unposted image post with score >= %d",
+                            subreddit, threshold)
                 continue
+            score = scores.get(choice["reddit_id"], 0)
             caption = telegram_publisher.build_caption(
                 choice["title"], subreddit, choice["permalink"])
             images = [choice["image_url"]]
@@ -70,9 +80,9 @@ def publish_once(dry_run=False):
                 if len(gallery) > 1:
                     images = gallery
             if dry_run:
-                logger.info("r/%s: would publish '%s' (%s), %d image(s)",
+                logger.info("r/%s: would publish '%s' (%s), score %d, %d image(s)",
                             subreddit, choice["title"], choice["reddit_id"],
-                            len(images))
+                            score, len(images))
                 continue
             if len(images) > 1:
                 result = telegram_publisher.send_media_group(
@@ -84,8 +94,8 @@ def publish_once(dry_run=False):
             published_store.mark_published(
                 connection, choice["reddit_id"], subreddit,
                 choice["title"], choice["permalink"], message_id)
-            logger.info("r/%s: published '%s' as message_id=%s",
-                        subreddit, choice["title"], message_id)
+            logger.info("r/%s: published '%s' (score %d) as message_id=%s",
+                        subreddit, choice["title"], score, message_id)
             published.append((subreddit, choice["title"], message_id))
     finally:
         connection.close()

--- a/app/published_store.py
+++ b/app/published_store.py
@@ -4,11 +4,17 @@ import sqlite3
 import time
 from pathlib import Path
 
-DEFAULT_DB = "published.sqlite"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_DB = "data/published.sqlite"
 
 
 def store_path():
-    return Path(os.getenv("PUBLISHED_DB", DEFAULT_DB)).resolve()
+    # A relative PUBLISHED_DB resolves against the repo root, not the current
+    # working directory, so every entry point shares one dedup store.
+    path = Path(os.getenv("PUBLISHED_DB", DEFAULT_DB))
+    if not path.is_absolute():
+        path = REPO_ROOT / path
+    return path.resolve()
 
 
 def open_store():

--- a/app/published_store.py
+++ b/app/published_store.py
@@ -1,0 +1,53 @@
+"""Persistent record of already-published Reddit posts, to avoid reposting."""
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+DEFAULT_DB = "published.sqlite"
+
+
+def store_path():
+    return Path(os.getenv("PUBLISHED_DB", DEFAULT_DB)).resolve()
+
+
+def open_store():
+    path = store_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(path)
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS published (
+            reddit_id TEXT PRIMARY KEY,
+            subreddit TEXT NOT NULL,
+            title TEXT NOT NULL,
+            permalink TEXT NOT NULL,
+            telegram_message_id INTEGER,
+            published_at INTEGER NOT NULL
+        )
+        """
+    )
+    connection.commit()
+    return connection
+
+
+def is_published(connection, reddit_id):
+    row = connection.execute(
+        "SELECT 1 FROM published WHERE reddit_id = ?", (reddit_id,)
+    ).fetchone()
+    return row is not None
+
+
+def mark_published(connection, reddit_id, subreddit, title, permalink,
+                   telegram_message_id):
+    connection.execute(
+        """
+        INSERT OR REPLACE INTO published
+            (reddit_id, subreddit, title, permalink,
+             telegram_message_id, published_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (reddit_id, subreddit, title, permalink,
+         telegram_message_id, int(time.time())),
+    )
+    connection.commit()

--- a/app/telegram_publisher.py
+++ b/app/telegram_publisher.py
@@ -1,7 +1,10 @@
-"""Post a Reddit meme (photo + caption) to a Telegram channel."""
+"""Post a Reddit meme (photo or album + caption) to a Telegram channel."""
 import html
+import json
 
 import requests
+
+TELEGRAM_ALBUM_LIMIT = 10
 
 USER_AGENT = ("Mozilla/5.0 (X11; Linux x86_64; rv:128.0) "
               "Gecko/20100101 Firefox/128.0")
@@ -41,3 +44,39 @@ def send_photo(token, chat_id, image_url, caption):
     if result.get("ok"):
         return result["result"]
     raise RuntimeError(f"sendPhoto failed: {result.get('description')}")
+
+
+def send_media_group(token, chat_id, image_urls, caption):
+    """Post several images as a single album; caption sits on the first image."""
+    items = image_urls[:TELEGRAM_ALBUM_LIMIT]
+
+    def build_media(reference_for):
+        media = []
+        for index, reference in enumerate(reference_for):
+            entry = {"type": "photo", "media": reference}
+            if index == 0:
+                entry["caption"] = caption
+                entry["parse_mode"] = "HTML"
+            media.append(entry)
+        return media
+
+    result = call(token, "sendMediaGroup",
+                  {"chat_id": chat_id, "media": json.dumps(build_media(items))})
+    if result.get("ok"):
+        return result["result"][0]
+
+    # Telegram could not fetch the URLs itself: download and upload the bytes.
+    files = {}
+    references = []
+    for index, url in enumerate(items):
+        image = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=30)
+        image.raise_for_status()
+        name = f"photo{index}"
+        files[name] = (f"{name}.jpg", image.content)
+        references.append(f"attach://{name}")
+    result = call(token, "sendMediaGroup",
+                  {"chat_id": chat_id, "media": json.dumps(build_media(references))},
+                  files=files)
+    if result.get("ok"):
+        return result["result"][0]
+    raise RuntimeError(f"sendMediaGroup failed: {result.get('description')}")

--- a/app/telegram_publisher.py
+++ b/app/telegram_publisher.py
@@ -12,7 +12,7 @@ USER_AGENT = ("Mozilla/5.0 (X11; Linux x86_64; rv:128.0) "
 
 def build_caption(title, subreddit, permalink):
     return (
-        f"🍝 <b>{html.escape(title)}</b>\n"
+        f"<b>{html.escape(title)}</b>\n"
         f'<a href="{permalink}">r/{subreddit}</a>'
     )
 

--- a/app/telegram_publisher.py
+++ b/app/telegram_publisher.py
@@ -1,0 +1,43 @@
+"""Post a Reddit meme (photo + caption) to a Telegram channel."""
+import html
+
+import requests
+
+USER_AGENT = ("Mozilla/5.0 (X11; Linux x86_64; rv:128.0) "
+              "Gecko/20100101 Firefox/128.0")
+
+
+def build_caption(title, subreddit, permalink):
+    return (
+        f"🍝 <b>{html.escape(title)}</b>\n"
+        f'<a href="{permalink}">r/{subreddit}</a>'
+    )
+
+
+def call(token, method, payload=None, files=None):
+    response = requests.post(
+        f"https://api.telegram.org/bot{token}/{method}",
+        data=payload, files=files, timeout=30,
+    )
+    return response.json()
+
+
+def send_photo(token, chat_id, image_url, caption):
+    result = call(token, "sendPhoto", {
+        "chat_id": chat_id,
+        "photo": image_url,
+        "caption": caption,
+        "parse_mode": "HTML",
+    })
+    if result.get("ok"):
+        return result["result"]
+
+    # Telegram could not fetch the URL itself: download and upload the bytes.
+    image = requests.get(image_url, headers={"User-Agent": USER_AGENT}, timeout=30)
+    image.raise_for_status()
+    result = call(token, "sendPhoto",
+                  {"chat_id": chat_id, "caption": caption, "parse_mode": "HTML"},
+                  files={"photo": ("meme.jpg", image.content)})
+    if result.get("ok"):
+        return result["result"]
+    raise RuntimeError(f"sendPhoto failed: {result.get('description')}")

--- a/app/trend_scheduler.py
+++ b/app/trend_scheduler.py
@@ -1,0 +1,51 @@
+"""Run the trend publisher on a fixed daily schedule (default twice a day).
+
+PUBLISH_TIMES is a comma-separated list of HH:MM slots in UTC. Each slot
+fires publish_once(), which posts one meme per tracked subreddit.
+"""
+import logging
+import os
+import sys
+from pathlib import Path
+
+from apscheduler.schedulers.blocking import BlockingScheduler
+from apscheduler.triggers.cron import CronTrigger
+from dotenv import load_dotenv
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import publish_trends
+
+logger = logging.getLogger("trend_scheduler")
+DEFAULT_TIMES = "09:00,21:00"
+
+
+def scheduled_run():
+    try:
+        publish_trends.publish_once()
+    except Exception as error:
+        logger.exception("scheduled publish failed: %s", error)
+
+
+def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    load_dotenv()
+    times = os.getenv("PUBLISH_TIMES", DEFAULT_TIMES)
+    scheduler = BlockingScheduler(timezone="UTC")
+    for slot in [item.strip() for item in times.split(",") if item.strip()]:
+        hour, sep, minute = slot.partition(":")
+        scheduler.add_job(
+            scheduled_run,
+            trigger=CronTrigger(hour=int(hour), minute=int(minute or 0)),
+            id=f"publish_{slot}",
+            replace_existing=True,
+        )
+        logger.info("scheduled daily publish at %s UTC", slot)
+    logger.info("trend scheduler started")
+    scheduler.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/app/trend_watcher.py
+++ b/app/trend_watcher.py
@@ -18,6 +18,8 @@ USER_AGENT = ("Mozilla/5.0 (X11; Linux x86_64; rv:128.0) "
 IREDD_RE = re.compile(r"https://i\.redd\.it/[A-Za-z0-9]+\.[A-Za-z0-9]+")
 PREVIEW_RE = re.compile(r"https://preview\.redd\.it/([A-Za-z0-9]+\.[A-Za-z0-9]+)")
 COMMENTS_RE = re.compile(r"/comments/([a-z0-9]+)/")
+GALLERY_RE = re.compile(r"reddit\.com/gallery/[a-z0-9]+")
+MEDIA_TILE_RE = re.compile(r'id="media-tile-([a-z0-9]+)-([A-Za-z0-9]+)"')
 
 
 def fetch_rising(subreddit, retries=4, pause=35):
@@ -48,6 +50,7 @@ def parse_feed(subreddit, raw_xml):
             permalink = link.get("href", "")
         permalink = permalink.replace("old.reddit.com", "reddit.com")
         match = COMMENTS_RE.search(permalink)
+        text = html.unescape(content)
         candidates.append({
             "subreddit": subreddit,
             "reddit_id": match.group(1) if match else None,
@@ -55,6 +58,7 @@ def parse_feed(subreddit, raw_xml):
             "author": author,
             "permalink": permalink,
             "image_url": extract_image(entry, content),
+            "is_gallery": bool(GALLERY_RE.search(text)) or "/gallery/" in permalink,
         })
     return candidates
 
@@ -79,3 +83,35 @@ def extract_image(entry, content):
         if preview:
             return f"https://i.redd.it/{preview.group(1)}"
     return None
+
+
+def gallery_image_urls(permalink, post_id, retries=4, pause=35):
+    """Return every image of a gallery post, in order, at full resolution.
+
+    Reddit's RSS lists only one thumbnail for a gallery, and the JSON API
+    rejects datacenter IPs. The old.reddit HTML page stays reachable and marks
+    each gallery image with id="media-tile-<post>-<media>", which maps to the
+    original at i.redd.it/<media>.<ext>. Returns [] if the page can't be read.
+    """
+    old_permalink = permalink.replace("://reddit.com", "://old.reddit.com")
+    old_permalink = old_permalink.replace("://www.reddit.com", "://old.reddit.com")
+    response = None
+    for attempt in range(retries):
+        if attempt:
+            time.sleep(pause * attempt)
+        response = requests.get(
+            old_permalink, headers={"User-Agent": USER_AGENT}, timeout=20)
+        if response.status_code != 429:
+            break
+    if response is None or response.status_code != 200:
+        return []
+    page = response.text
+    urls = []
+    seen = set()
+    for tile_post, media_id in MEDIA_TILE_RE.findall(page):
+        if tile_post != post_id or media_id in seen:
+            continue
+        seen.add(media_id)
+        extension = re.search(re.escape(media_id) + r"\.(jpg|jpeg|png|gif)", page)
+        urls.append(f"https://i.redd.it/{media_id}.{extension.group(1) if extension else 'jpg'}")
+    return urls

--- a/app/trend_watcher.py
+++ b/app/trend_watcher.py
@@ -1,0 +1,68 @@
+"""Fetch rising Reddit posts via public Atom feeds — no OAuth required.
+
+Reddit's JSON endpoints reject datacenter IPs, but the RSS/Atom feeds
+(/r/<sub>/rising.rss) stay open. They carry no score, so "best trending"
+means the feed order Reddit itself assigns to rising posts.
+"""
+import html
+import re
+import time
+import xml.etree.ElementTree as ElementTree
+
+import requests
+
+ATOM = "{http://www.w3.org/2005/Atom}"
+MEDIA = "{http://search.yahoo.com/mrss/}"
+USER_AGENT = ("Mozilla/5.0 (X11; Linux x86_64; rv:128.0) "
+              "Gecko/20100101 Firefox/128.0")
+IMAGE_RE = re.compile(r'href="(https://i\.redd\.it/[^"]+)"')
+COMMENTS_RE = re.compile(r"/comments/([a-z0-9]+)/")
+
+
+def fetch_rising(subreddit, retries=4, pause=35):
+    response = None
+    for attempt in range(retries):
+        if attempt:
+            time.sleep(pause * attempt)
+        response = requests.get(
+            f"https://old.reddit.com/r/{subreddit}/rising.rss",
+            headers={"User-Agent": USER_AGENT},
+            timeout=15,
+        )
+        if response.status_code != 429:
+            break
+    response.raise_for_status()
+    return parse_feed(subreddit, response.content)
+
+
+def parse_feed(subreddit, raw_xml):
+    root = ElementTree.fromstring(raw_xml)
+    candidates = []
+    for entry in root.iter(f"{ATOM}entry"):
+        title = entry.findtext(f"{ATOM}title", default="(no title)")
+        author = entry.findtext(f"{ATOM}author/{ATOM}name", default="?")
+        content = entry.findtext(f"{ATOM}content", default="")
+        permalink = ""
+        for link in entry.iter(f"{ATOM}link"):
+            permalink = link.get("href", "")
+        permalink = permalink.replace("old.reddit.com", "reddit.com")
+        match = COMMENTS_RE.search(permalink)
+        candidates.append({
+            "subreddit": subreddit,
+            "reddit_id": match.group(1) if match else None,
+            "title": title,
+            "author": author,
+            "permalink": permalink,
+            "image_url": extract_image(entry, content),
+        })
+    return candidates
+
+
+def extract_image(entry, content):
+    match = IMAGE_RE.search(html.unescape(content))
+    if match:
+        return match.group(1)
+    thumbnail = entry.find(f"{MEDIA}thumbnail")
+    if thumbnail is not None:
+        return thumbnail.get("url")
+    return None

--- a/app/trend_watcher.py
+++ b/app/trend_watcher.py
@@ -15,7 +15,8 @@ ATOM = "{http://www.w3.org/2005/Atom}"
 MEDIA = "{http://search.yahoo.com/mrss/}"
 USER_AGENT = ("Mozilla/5.0 (X11; Linux x86_64; rv:128.0) "
               "Gecko/20100101 Firefox/128.0")
-IMAGE_RE = re.compile(r'href="(https://i\.redd\.it/[^"]+)"')
+IREDD_RE = re.compile(r"https://i\.redd\.it/[A-Za-z0-9]+\.[A-Za-z0-9]+")
+PREVIEW_RE = re.compile(r"https://preview\.redd\.it/([A-Za-z0-9]+\.[A-Za-z0-9]+)")
 COMMENTS_RE = re.compile(r"/comments/([a-z0-9]+)/")
 
 
@@ -59,10 +60,22 @@ def parse_feed(subreddit, raw_xml):
 
 
 def extract_image(entry, content):
-    match = IMAGE_RE.search(html.unescape(content))
-    if match:
-        return match.group(1)
+    """Return a full-resolution image URL, never a tiny preview thumbnail.
+
+    Reddit's RSS often carries only a 140px preview.redd.it thumbnail (e.g. for
+    gallery posts). preview.redd.it/<id>.<ext> maps to the original at
+    i.redd.it/<id>.<ext>, so we upgrade previews instead of posting a thumbnail.
+    """
+    text = html.unescape(content)
+    direct = IREDD_RE.search(text)
+    if direct:
+        return direct.group(0)
+    preview = PREVIEW_RE.search(text)
+    if preview:
+        return f"https://i.redd.it/{preview.group(1)}"
     thumbnail = entry.find(f"{MEDIA}thumbnail")
     if thumbnail is not None:
-        return thumbnail.get("url")
+        preview = PREVIEW_RE.search(thumbnail.get("url", ""))
+        if preview:
+            return f"https://i.redd.it/{preview.group(1)}"
     return None

--- a/app/trend_watcher.py
+++ b/app/trend_watcher.py
@@ -20,6 +20,9 @@ PREVIEW_RE = re.compile(r"https://preview\.redd\.it/([A-Za-z0-9]+\.[A-Za-z0-9]+)
 COMMENTS_RE = re.compile(r"/comments/([a-z0-9]+)/")
 GALLERY_RE = re.compile(r"reddit\.com/gallery/[a-z0-9]+")
 MEDIA_TILE_RE = re.compile(r'id="media-tile-([a-z0-9]+)-([A-Za-z0-9]+)"')
+THING_RE = re.compile(r'<div\b([^>]*\bdata-fullname="t3_[a-z0-9]+"[^>]*)>')
+FULLNAME_RE = re.compile(r'data-fullname="t3_([a-z0-9]+)"')
+SCORE_RE = re.compile(r'data-score="(-?\d+)"')
 
 
 def fetch_rising(subreddit, retries=4, pause=35):
@@ -83,6 +86,33 @@ def extract_image(entry, content):
         if preview:
             return f"https://i.redd.it/{preview.group(1)}"
     return None
+
+
+def rising_scores(subreddit, retries=4, pause=35):
+    """Map reddit_id -> score from the old.reddit rising HTML.
+
+    The Atom feed carries no score and the JSON API rejects datacenter IPs, but
+    the HTML listing marks every post with data-fullname and data-score.
+    Returns {} if the page can't be read (callers then publish nothing).
+    """
+    response = None
+    for attempt in range(retries):
+        if attempt:
+            time.sleep(pause * attempt)
+        response = requests.get(
+            f"https://old.reddit.com/r/{subreddit}/rising/",
+            headers={"User-Agent": USER_AGENT}, timeout=20)
+        if response.status_code != 429:
+            break
+    if response is None or response.status_code != 200:
+        return {}
+    scores = {}
+    for attrs in THING_RE.findall(response.text):
+        fullname = FULLNAME_RE.search(attrs)
+        score = SCORE_RE.search(attrs)
+        if fullname and score:
+            scores[fullname.group(1)] = int(score.group(1))
+    return scores
 
 
 def gallery_image_urls(permalink, post_id, retries=4, pause=35):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  trend-publisher:
+    build: .
+    env_file:
+      - .env
+    environment:
+      # Keep the dedup store on a mounted volume so it survives restarts.
+      PUBLISHED_DB: /app/data/published.sqlite
+    volumes:
+      - ./data:/app/data
+    restart: unless-stopped

--- a/env.example
+++ b/env.example
@@ -14,6 +14,8 @@ TELEGRAM_TOKEN=your_bot_token_here
 TELEGRAM_CHANNEL_ID=-1000000000000
 # Comma-separated subreddits to watch (one post per subreddit per run)
 TREND_SUBREDDITS=ProgrammerHumor,funnyAnimals,linuxmemes
+# Only publish posts whose score is at least this value
+MIN_SCORE=1000
 # Comma-separated HH:MM slots in UTC (default: twice a day)
 PUBLISH_TIMES=09:00,21:00
 # SQLite file that remembers already-published posts

--- a/env.example
+++ b/env.example
@@ -9,4 +9,14 @@ DB_PATH=./news.db
 MEDIA_DIR=./media
 REDIRECT_PORT=8000
 
+# Telegram trend auto-publisher
+TELEGRAM_TOKEN=your_bot_token_here
+TELEGRAM_CHANNEL_ID=-1000000000000
+# Comma-separated subreddits to watch (one post per subreddit per run)
+TREND_SUBREDDITS=ProgrammerHumor,funnyAnimals
+# Comma-separated HH:MM slots in UTC (default: twice a day)
+PUBLISH_TIMES=09:00,21:00
+# SQLite file that remembers already-published posts
+PUBLISHED_DB=./data/published.sqlite
+
 

--- a/env.example
+++ b/env.example
@@ -13,7 +13,7 @@ REDIRECT_PORT=8000
 TELEGRAM_TOKEN=your_bot_token_here
 TELEGRAM_CHANNEL_ID=-1000000000000
 # Comma-separated subreddits to watch (one post per subreddit per run)
-TREND_SUBREDDITS=ProgrammerHumor,funnyAnimals
+TREND_SUBREDDITS=ProgrammerHumor,funnyAnimals,linuxmemes
 # Comma-separated HH:MM slots in UTC (default: twice a day)
 PUBLISH_TIMES=09:00,21:00
 # SQLite file that remembers already-published posts

--- a/tools/backfill_published.py
+++ b/tools/backfill_published.py
@@ -2,6 +2,8 @@
 import sys
 from pathlib import Path
 
+from dotenv import load_dotenv
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "app"))
 
 import published_store
@@ -19,6 +21,7 @@ ALREADY_SENT = [
 
 
 def main():
+    load_dotenv()
     connection = published_store.open_store()
     try:
         for record in ALREADY_SENT:

--- a/tools/backfill_published.py
+++ b/tools/backfill_published.py
@@ -1,0 +1,40 @@
+"""Record an already-published post so the auto-publisher never reposts it."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "app"))
+
+import published_store
+
+ALREADY_SENT = [
+    {
+        "reddit_id": "1uo0dx2",
+        "subreddit": "ProgrammerHumor",
+        "title": "somebodyTouchaMySpaghet",
+        "permalink": "https://reddit.com/r/ProgrammerHumor/comments/"
+                     "1uo0dx2/somebodytouchamyspaghet/",
+        "telegram_message_id": 5,
+    },
+]
+
+
+def main():
+    connection = published_store.open_store()
+    try:
+        for record in ALREADY_SENT:
+            published_store.mark_published(
+                connection,
+                record["reddit_id"],
+                record["subreddit"],
+                record["title"],
+                record["permalink"],
+                record["telegram_message_id"],
+            )
+            print(f"recorded {record['reddit_id']} "
+                  f"(message_id={record['telegram_message_id']}) as published")
+    finally:
+        connection.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds an automated pipeline that posts trending Reddit memes to a Telegram channel twice a day.

- Fetches **rising** posts per subreddit in `TREND_SUBREDDITS` via Reddit's public **Atom feeds** — no OAuth, which the JSON API denies from datacenter IPs.
- Picks the best post that has an image and has **not been published yet** (SQLite dedup store keyed by Reddit post id; also records the Telegram `message_id`).
- Sends **photo + caption** (title + `r/<subreddit>` link) to the channel.
- One post per tracked subreddit per run, driven by an APScheduler cron (`PUBLISH_TIMES`, default `09:00,21:00` UTC) — so **2 subreddits → 4 posts/day**.
- `Dockerfile` + `docker-compose.yml` run the scheduler unattended with a mounted dedup store.
- `tools/backfill_published.py` records an already-sent meme so it is never reposted.

New modules: `app/trend_watcher.py`, `app/telegram_publisher.py`, `app/published_store.py`, `app/publish_trends.py`, `app/trend_scheduler.py`. New env vars documented in `env.example`.

## Test plan

- [x] All new modules compile (`py_compile`).
- [x] `tools/backfill_published.py` records the already-sent post; store shows `('1uo0dx2','ProgrammerHumor',5)`.
- [x] `publish_trends.py --dry-run` skips the already-published ProgrammerHumor post and selects the next one; selects the top funnyAnimals post — confirms dedup + per-subreddit selection without posting.
- [x] Live caption verified on the channel (title + `r/ProgrammerHumor` link, single newline).
- [ ] `docker compose up --build` on the deployment host.