### PR TITLE
Add GitHub FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# These are supported funding model platforms
+github: [yumiaura]
+buy_me_a_coffee: yumiaura
+patreon: yumiaura

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 ### Added
+- `.github/FUNDING.yml` with GitHub Sponsors, Buy Me a Coffee and Patreon links
+  (`chore/funding`).
 - Trend auto-publisher (`feat/trend-publisher`): fetches rising posts for each
   subreddit in `TREND_SUBREDDITS` via public Atom feeds (no OAuth needed),
   picks the best not-yet-published post that has an image, and sends


### PR DESCRIPTION
## Summary
Adds `.github/FUNDING.yml` so the repository shows a **Sponsor** button, matching the funding configuration used in the myCat repo.

- GitHub Sponsors: `yumiaura`
- Buy Me a Coffee: `yumiaura`
- Patreon: `yumiaura`

## Test plan
- [x] Valid YAML, correct path `.github/FUNDING.yml`.
- [ ] GitHub renders the Sponsor button on the repo page after merge.