### PR TITLE
Lower default MIN_SCORE to 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ### Added
 - `.github/FUNDING.yml` with GitHub Sponsors, Buy Me a Coffee and Patreon links
   (`chore/funding`).
+
+### Changed
+- Default `MIN_SCORE` lowered from 1000 to 500 (`chore/min-score-500`). It is a
+  per-post threshold (each published post needs at least this many upvotes), not
+  a total across posts; rising posts rarely reach 1000 so 1000 left channels
+  like r/funnyAnimals with nothing to publish.
 - Trend auto-publisher (`feat/trend-publisher`): fetches rising posts for each
   subreddit in `TREND_SUBREDDITS` via public Atom feeds (no OAuth needed),
   picks the best not-yet-published post that has an image, and sends

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Add these to your `.env` (see `env.example`):
 | `TELEGRAM_TOKEN` | Bot token from @BotFather | *Required* |
 | `TELEGRAM_CHANNEL_ID` | Target channel id (e.g. `-1001234567890`) | *Required* |
 | `TREND_SUBREDDITS` | Comma-separated subreddits to watch | `ProgrammerHumor` |
-| `MIN_SCORE` | Only publish posts with at least this score | `1000` |
+| `MIN_SCORE` | Minimum score (upvotes) per published post | `500` |
 | `PUBLISH_TIMES` | Comma-separated `HH:MM` slots in UTC | `09:00,21:00` |
 | `PUBLISHED_DB` | Path to the dedup SQLite store | `./data/published.sqlite` |
 

--- a/app/publish_trends.py
+++ b/app/publish_trends.py
@@ -20,7 +20,7 @@ import trend_watcher
 
 logger = logging.getLogger("trend_publisher")
 DEFAULT_SUBREDDITS = "ProgrammerHumor"
-DEFAULT_MIN_SCORE = 1000
+DEFAULT_MIN_SCORE = 500
 RATE_LIMIT_PAUSE = 30
 
 

--- a/env.example
+++ b/env.example
@@ -14,8 +14,9 @@ TELEGRAM_TOKEN=your_bot_token_here
 TELEGRAM_CHANNEL_ID=-1000000000000
 # Comma-separated subreddits to watch (one post per subreddit per run)
 TREND_SUBREDDITS=ProgrammerHumor,funnyAnimals,linuxmemes
-# Only publish posts whose score is at least this value
-MIN_SCORE=1000
+# Only publish posts whose score (upvotes) is at least this value.
+# This is a per-post threshold, not a total across posts.
+MIN_SCORE=500
 # Comma-separated HH:MM slots in UTC (default: twice a day)
 PUBLISH_TIMES=09:00,21:00
 # SQLite file that remembers already-published posts


### PR DESCRIPTION
## Summary
`MIN_SCORE` is a **per-post** threshold (each published post needs at least this many upvotes), not a total across posts. Rising posts rarely reach 1000, so a 1000 default left channels like r/funnyAnimals with nothing to publish. This lowers the general default to **500** and clarifies the meaning in the docs.

- `app/publish_trends.py`: `DEFAULT_MIN_SCORE` 1000 → 500
- `env.example`: `MIN_SCORE=500` with a clarifying comment
- `README.md`: table default 500, wording "minimum score per published post"

## Test plan
- [x] With 500, r/funnyAnimals rising has qualifying image posts (scores 919, 837, 718, 688…).
- [x] Live run posted 'Dumber than he looks' (score 530) to the channel.
- [x] Module compiles.