### PR TITLE
Configurable timezone for publish slots (PUBLISH_TZ)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Added
 - `.github/FUNDING.yml` with GitHub Sponsors, Buy Me a Coffee and Patreon links
   (`chore/funding`).
+- Configurable publish timezone: `PUBLISH_TIMES` slots are now interpreted in
+  the `PUBLISH_TZ` IANA timezone (default `UTC`, e.g. `Europe/Lisbon`).
+  An invalid name fails at startup with a clear error instead of silently
+  scheduling in the wrong timezone (`feat/publish-timezone`).
 
 ### Changed
 - Default `MIN_SCORE` lowered from 1000 to 500 (`chore/min-score-500`). It is a

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Add these to your `.env` (see `env.example`):
 | `TREND_SUBREDDITS` | Comma-separated subreddits to watch | `ProgrammerHumor` |
 | `MIN_SCORE` | Minimum score (upvotes) per published post | `500` |
 | `TREND_LISTINGS` | Listing chain tried in order (`name[:period]`) | `rising,top:week` |
-| `PUBLISH_TIMES` | Comma-separated `HH:MM` slots in UTC | `09:00,21:00` |
+| `PUBLISH_TIMES` | Comma-separated `HH:MM` slots in `PUBLISH_TZ` | `09:00,21:00` |
+| `PUBLISH_TZ` | IANA timezone for the publish slots (e.g. `Europe/Lisbon`) | `UTC` |
 | `PUBLISHED_DB` | Path to the dedup SQLite store | `./data/published.sqlite` |
 
 ### Running

--- a/app/trend_scheduler.py
+++ b/app/trend_scheduler.py
@@ -1,7 +1,8 @@
 """Run the trend publisher on a fixed daily schedule (default twice a day).
 
-PUBLISH_TIMES is a comma-separated list of HH:MM slots in UTC. Each slot
-fires publish_once(), which posts one meme per tracked subreddit.
+PUBLISH_TIMES is a comma-separated list of HH:MM slots interpreted in the
+PUBLISH_TZ timezone (IANA name, default UTC). Each slot fires
+publish_once(), which posts one meme per tracked subreddit.
 """
 import logging
 import os
@@ -9,6 +10,7 @@ import signal
 import sys
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 from apscheduler.schedulers.blocking import BlockingScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -21,7 +23,17 @@ import publish_trends
 
 logger = logging.getLogger("trend_scheduler")
 DEFAULT_TIMES = "09:00,21:00"
+DEFAULT_TZ = "UTC"
 LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+
+def publish_timezone():
+    """IANA timezone the PUBLISH_TIMES slots are interpreted in.
+
+    ZoneInfo validates the name, so a typo fails at startup with a clear
+    error instead of silently scheduling in the wrong timezone.
+    """
+    return ZoneInfo(os.getenv("PUBLISH_TZ", DEFAULT_TZ).strip() or DEFAULT_TZ)
 
 
 def setup_logging():
@@ -52,16 +64,18 @@ def main():
     setup_logging()
     load_dotenv()
     times = os.getenv("PUBLISH_TIMES", DEFAULT_TIMES)
-    scheduler = BlockingScheduler(timezone="UTC")
+    timezone = publish_timezone()
+    scheduler = BlockingScheduler(timezone=timezone)
     for slot in [item.strip() for item in times.split(",") if item.strip()]:
         hour, sep, minute = slot.partition(":")
         scheduler.add_job(
             scheduled_run,
-            trigger=CronTrigger(hour=int(hour), minute=int(minute or 0)),
+            trigger=CronTrigger(hour=int(hour), minute=int(minute or 0),
+                                timezone=timezone),
             id=f"publish_{slot}",
             replace_existing=True,
         )
-        logger.info("scheduled daily publish at %s UTC", slot)
+        logger.info("scheduled daily publish at %s %s", slot, timezone)
 
     heartbeat_file = os.getenv("HEARTBEAT_FILE", "").strip()
     if heartbeat_file:

--- a/env.example
+++ b/env.example
@@ -25,8 +25,10 @@ MIN_SCORE=500
 # Listings tried in order until one yields a publishable post.
 # "name" or "name:period", e.g. rising, top:week, top:month
 TREND_LISTINGS=rising,top:week
-# Comma-separated HH:MM slots in UTC (default: twice a day)
+# Comma-separated HH:MM slots in PUBLISH_TZ (default: twice a day)
 PUBLISH_TIMES=09:00,21:00
+# IANA timezone the PUBLISH_TIMES slots are interpreted in
+PUBLISH_TZ=UTC
 # SQLite file that remembers already-published posts
 PUBLISHED_DB=./data/published.sqlite
 # Optional rotating log file for the scheduler (5 MB x 3); empty = console only

--- a/tests/test_trend_scheduler.py
+++ b/tests/test_trend_scheduler.py
@@ -1,0 +1,27 @@
+"""Timezone handling tests for trend_scheduler."""
+from zoneinfo import ZoneInfo
+
+import pytest
+
+import trend_scheduler
+
+
+def test_default_timezone_is_utc(monkeypatch):
+    monkeypatch.delenv("PUBLISH_TZ", raising=False)
+    assert trend_scheduler.publish_timezone() == ZoneInfo("UTC")
+
+
+def test_env_timezone_override(monkeypatch):
+    monkeypatch.setenv("PUBLISH_TZ", " Europe/Lisbon ")
+    assert trend_scheduler.publish_timezone() == ZoneInfo("Europe/Lisbon")
+
+
+def test_empty_env_falls_back_to_utc(monkeypatch):
+    monkeypatch.setenv("PUBLISH_TZ", "")
+    assert trend_scheduler.publish_timezone() == ZoneInfo("UTC")
+
+
+def test_invalid_timezone_fails_loudly(monkeypatch):
+    monkeypatch.setenv("PUBLISH_TZ", "Europe/Lisboa")
+    with pytest.raises(Exception):
+        trend_scheduler.publish_timezone()


### PR DESCRIPTION
## Summary

- `PUBLISH_TIMES` slots are now interpreted in the `PUBLISH_TZ` IANA timezone
  (default `UTC`) instead of hardcoded UTC — e.g. `PUBLISH_TZ=Europe/Lisbon`
  makes the channel post at 09:00/21:00 Lisbon time year-round, DST included.
- The name is validated through `zoneinfo.ZoneInfo` at startup, so a typo
  fails loudly instead of silently scheduling in the wrong timezone.
- Documented in `env.example` and the README config table.

## Test plan

- [x] 4 new tests (47 total passing): default UTC, env override,
  empty-value fallback, invalid name raises
- [x] `ruff check .` clean
- [x] Live run with `PUBLISH_TZ=Europe/Lisbon`: scheduler logs
  `scheduled daily publish at 09:00 Europe/Lisbon` / `21:00 Europe/Lisbon`,
  SIGTERM shutdown still clean
- [x] `ZoneInfo('Europe/Lisbon')` resolves inside the `python:3.11-slim`
  container — no new dependency needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)