### PR TITLE
Configurable container uid (APP_UID) so ./data stays writable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
   An invalid name fails at startup with a clear error instead of silently
   scheduling in the wrong timezone (`feat/publish-timezone`).
 
+### Fixed (deployment)
+- The container user's uid is now the `APP_UID` build argument (set it in
+  `.env` to `id -u`, default 1000) instead of hardcoded 1000. On hosts where
+  the user is not uid 1000 the publisher could send a Telegram post and then
+  crash with "attempt to write a readonly database" before recording it in
+  the dedup store — a repost risk (`fix/container-uid`).
+
 ### Changed
 - Default `MIN_SCORE` lowered from 1000 to 500 (`chore/min-score-500`). It is a
   per-post threshold (each published post needs at least this many upvotes), not

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,10 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-# uid 1000 matches the typical host user so the mounted ./data volume
-# stays writable
-RUN useradd --create-home --uid 1000 appuser && chown -R appuser /app
+# Match the host user's uid (APP_UID build arg, see docker-compose.yml)
+# so the mounted ./data volume stays writable both ways.
+ARG APP_UID=1000
+RUN useradd --create-home --uid ${APP_UID} appuser && chown -R appuser /app
 USER appuser
 
 # The scheduler refreshes this file every minute; a stale file means the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,11 @@
 services:
   trend-publisher:
-    build: .
+    build:
+      context: .
+      args:
+        # Set APP_UID in .env to your host uid (id -u) so the container
+        # user can write the mounted ./data volume.
+        APP_UID: "${APP_UID:-1000}"
     env_file:
       - .env
     environment:

--- a/env.example
+++ b/env.example
@@ -33,5 +33,8 @@ PUBLISH_TZ=UTC
 PUBLISHED_DB=./data/published.sqlite
 # Optional rotating log file for the scheduler (5 MB x 3); empty = console only
 LOG_FILE=
+# Host uid the container user is built with (run `id -u`), so the mounted
+# ./data volume stays writable
+APP_UID=1000
 
 


### PR DESCRIPTION
## Summary

- The Dockerfile hardcoded `useradd --uid 1000`; on hosts where the user is a
  different uid (this deployment: 1001) the mounted `./data` volume was
  read-only for the container, so the publisher **sent a Telegram post and
  then crashed** in `mark_published` ("attempt to write a readonly
  database") — the post was never recorded in the dedup store (repost risk).
- The uid is now the `APP_UID` build arg; `docker-compose.yml` passes
  `${APP_UID:-1000}` from `.env`, documented in `env.example` (`id -u`).

## Test plan

- [x] Rebuild with `APP_UID=1001`: container user matches the host owner of
  `data/published.sqlite`, write test passes (see deployment notes)
- [x] The post sent by the crashed run (`1uonvay`, message_id 19) backfilled
  into the dedup store
- [x] CI (ruff + pytest) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)