### PR TITLE
Stagger posts ~hourly within each publish slot (PUBLISH_INTERVAL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
   the `PUBLISH_TZ` IANA timezone (default `UTC`, e.g. `Europe/Lisbon`).
   An invalid name fails at startup with a clear error instead of silently
   scheduling in the wrong timezone (`feat/publish-timezone`).
+- Staggered publishing: within each `PUBLISH_TIMES` slot the tracked
+  subreddits now post `PUBLISH_INTERVAL` minutes apart (default 60) via one
+  cron job per (slot, subreddit), so the channel gets roughly one post per
+  hour instead of a burst of three. Restart-safe — no long sleeps inside a
+  job (`feat/staggered-publish`).
 
 ### Fixed (deployment)
 - The container user's uid is now the `APP_UID` build argument (set it in

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ There are two independent parts, and you can run either on its own:
   Telegram `message_id`, so nothing is ever posted twice.
 - One post per tracked subreddit per run. With three subreddits on the default
   twice-a-day schedule, that's up to **six posts per day**.
+- Within a slot the subreddits are staggered `PUBLISH_INTERVAL` minutes apart
+  (default 60), so the channel gets roughly one post per hour instead of a
+  burst of three.
 
 ### Configuration
 
@@ -52,6 +55,7 @@ Add these to your `.env` (see `env.example`):
 | `TREND_LISTINGS` | Listing chain tried in order (`name[:period]`) | `rising,top:week` |
 | `PUBLISH_TIMES` | Comma-separated `HH:MM` slots in `PUBLISH_TZ` | `09:00,21:00` |
 | `PUBLISH_TZ` | IANA timezone for the publish slots (e.g. `Europe/Lisbon`) | `UTC` |
+| `PUBLISH_INTERVAL` | Minutes between subreddits within a slot | `60` |
 | `PUBLISHED_DB` | Path to the dedup SQLite store | `./data/published.sqlite` |
 
 ### Running

--- a/app/publish_trends.py
+++ b/app/publish_trends.py
@@ -81,17 +81,25 @@ def select_candidate(connection, subreddit, threshold):
     return None, {}
 
 
-def publish_once(dry_run=False):
+def publish_once(dry_run=False, subreddits=None):
+    """Publish one post per subreddit; defaults to all tracked subreddits.
+
+    The scheduler passes a single-subreddit list so posts spread out over
+    the day instead of going out back-to-back.
+    """
     load_dotenv()
     token = os.getenv("TELEGRAM_TOKEN")
     chat_id = os.getenv("TELEGRAM_CHANNEL_ID")
     if not token or not chat_id:
         raise SystemExit("TELEGRAM_TOKEN and TELEGRAM_CHANNEL_ID are required")
 
+    if subreddits is None:
+        subreddits = tracked_subreddits()
+
     connection = published_store.open_store()
     published = []
     try:
-        for position, subreddit in enumerate(tracked_subreddits()):
+        for position, subreddit in enumerate(subreddits):
             if position:
                 time.sleep(RATE_LIMIT_PAUSE)  # respect Reddit's RSS rate limit
             threshold = min_score()

--- a/app/trend_scheduler.py
+++ b/app/trend_scheduler.py
@@ -1,8 +1,9 @@
 """Run the trend publisher on a fixed daily schedule (default twice a day).
 
 PUBLISH_TIMES is a comma-separated list of HH:MM slots interpreted in the
-PUBLISH_TZ timezone (IANA name, default UTC). Each slot fires
-publish_once(), which posts one meme per tracked subreddit.
+PUBLISH_TZ timezone (IANA name, default UTC). Within each slot the tracked
+subreddits are staggered PUBLISH_INTERVAL minutes apart (default 60), so
+posts go out roughly once an hour instead of all at once.
 """
 import logging
 import os
@@ -23,6 +24,7 @@ import publish_trends
 
 logger = logging.getLogger("trend_scheduler")
 DEFAULT_TIMES = "09:00,21:00"
+DEFAULT_INTERVAL_MINUTES = 60
 DEFAULT_TZ = "UTC"
 LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
@@ -48,9 +50,32 @@ def setup_logging():
         logger.info("also logging to %s (rotating, 5 MB x 3)", log_file)
 
 
-def scheduled_run():
+def publish_interval_minutes():
+    """Minutes between two subreddits' posts within one PUBLISH_TIMES slot."""
+    return int(os.getenv("PUBLISH_INTERVAL", DEFAULT_INTERVAL_MINUTES))
+
+
+def staggered_schedule(slots, subreddits, interval_minutes):
+    """Expand slots × subreddits into per-post times, one hour-ish apart.
+
+    Each subreddit is offset by its position × interval_minutes from the
+    slot, so a slot fans out over hours instead of posting everything at
+    once. Returns [(hour, minute, subreddit)]; times wrap around midnight.
+    """
+    schedule = []
+    for slot in slots:
+        hour, sep, minute = slot.partition(":")
+        base = int(hour) * 60 + int(minute or 0)
+        for position, subreddit in enumerate(subreddits):
+            total = base + position * interval_minutes
+            schedule.append(((total // 60) % 24, total % 60, subreddit))
+    return schedule
+
+
+def scheduled_run(subreddit=None):
     try:
-        publish_trends.publish_once()
+        publish_trends.publish_once(
+            subreddits=[subreddit] if subreddit else None)
     except Exception as error:
         logger.exception("scheduled publish failed: %s", error)
 
@@ -64,18 +89,21 @@ def main():
     setup_logging()
     load_dotenv()
     times = os.getenv("PUBLISH_TIMES", DEFAULT_TIMES)
+    slots = [item.strip() for item in times.split(",") if item.strip()]
+    subreddits = publish_trends.tracked_subreddits()
     timezone = publish_timezone()
     scheduler = BlockingScheduler(timezone=timezone)
-    for slot in [item.strip() for item in times.split(",") if item.strip()]:
-        hour, sep, minute = slot.partition(":")
+    for hour, minute, subreddit in staggered_schedule(
+            slots, subreddits, publish_interval_minutes()):
         scheduler.add_job(
             scheduled_run,
-            trigger=CronTrigger(hour=int(hour), minute=int(minute or 0),
-                                timezone=timezone),
-            id=f"publish_{slot}",
+            args=[subreddit],
+            trigger=CronTrigger(hour=hour, minute=minute, timezone=timezone),
+            id=f"publish_{hour:02d}{minute:02d}_{subreddit}",
             replace_existing=True,
         )
-        logger.info("scheduled daily publish at %s %s", slot, timezone)
+        logger.info("scheduled daily publish for r/%s at %02d:%02d %s",
+                    subreddit, hour, minute, timezone)
 
     heartbeat_file = os.getenv("HEARTBEAT_FILE", "").strip()
     if heartbeat_file:

--- a/env.example
+++ b/env.example
@@ -29,6 +29,9 @@ TREND_LISTINGS=rising,top:week
 PUBLISH_TIMES=09:00,21:00
 # IANA timezone the PUBLISH_TIMES slots are interpreted in
 PUBLISH_TZ=UTC
+# Minutes between two subreddits' posts within one slot, so posts spread
+# out (~hourly) instead of going out all at once
+PUBLISH_INTERVAL=60
 # SQLite file that remembers already-published posts
 PUBLISHED_DB=./data/published.sqlite
 # Optional rotating log file for the scheduler (5 MB x 3); empty = console only

--- a/tests/test_publish_trends.py
+++ b/tests/test_publish_trends.py
@@ -177,3 +177,36 @@ def test_select_candidate_skips_published_in_fallback(store, listing_stubs):
     choice, scores = publish_trends.select_candidate(store, "ProgrammerHumor", 500)
 
     assert choice["reddit_id"] == "1new77"
+
+
+def test_publish_once_limits_to_given_subreddits(monkeypatch, tmp_path):
+    monkeypatch.setenv("PUBLISHED_DB", str(tmp_path / "published.sqlite"))
+    monkeypatch.setenv("TELEGRAM_TOKEN", "token")
+    monkeypatch.setenv("TELEGRAM_CHANNEL_ID", "-100")
+    monkeypatch.setenv("TREND_SUBREDDITS", "ProgrammerHumor,funnyAnimals,linuxmemes")
+    asked = []
+
+    def fake_select(connection, subreddit, threshold):
+        asked.append(subreddit)
+        return None, {}
+
+    monkeypatch.setattr(publish_trends, "select_candidate", fake_select)
+    publish_trends.publish_once(dry_run=True, subreddits=["funnyAnimals"])
+    assert asked == ["funnyAnimals"]
+
+
+def test_publish_once_defaults_to_tracked_subreddits(monkeypatch, tmp_path):
+    monkeypatch.setenv("PUBLISHED_DB", str(tmp_path / "published.sqlite"))
+    monkeypatch.setenv("TELEGRAM_TOKEN", "token")
+    monkeypatch.setenv("TELEGRAM_CHANNEL_ID", "-100")
+    monkeypatch.setenv("TREND_SUBREDDITS", "a,b")
+    asked = []
+
+    def fake_select(connection, subreddit, threshold):
+        asked.append(subreddit)
+        return None, {}
+
+    monkeypatch.setattr(publish_trends, "select_candidate", fake_select)
+    monkeypatch.setattr(publish_trends.time, "sleep", lambda seconds: None)
+    publish_trends.publish_once(dry_run=True)
+    assert asked == ["a", "b"]

--- a/tests/test_trend_scheduler.py
+++ b/tests/test_trend_scheduler.py
@@ -25,3 +25,36 @@ def test_invalid_timezone_fails_loudly(monkeypatch):
     monkeypatch.setenv("PUBLISH_TZ", "Europe/Lisboa")
     with pytest.raises(Exception):
         trend_scheduler.publish_timezone()
+
+
+def test_staggered_schedule_default_layout():
+    schedule = trend_scheduler.staggered_schedule(
+        ["09:00", "21:00"], ["ProgrammerHumor", "funnyAnimals", "linuxmemes"], 60)
+    assert schedule == [
+        (9, 0, "ProgrammerHumor"),
+        (10, 0, "funnyAnimals"),
+        (11, 0, "linuxmemes"),
+        (21, 0, "ProgrammerHumor"),
+        (22, 0, "funnyAnimals"),
+        (23, 0, "linuxmemes"),
+    ]
+
+
+def test_staggered_schedule_wraps_past_midnight():
+    schedule = trend_scheduler.staggered_schedule(["23:30"], ["a", "b"], 60)
+    assert schedule == [(23, 30, "a"), (0, 30, "b")]
+
+
+def test_staggered_schedule_custom_interval():
+    schedule = trend_scheduler.staggered_schedule(["09:00"], ["a", "b", "c"], 90)
+    assert schedule == [(9, 0, "a"), (10, 30, "b"), (12, 0, "c")]
+
+
+def test_publish_interval_default(monkeypatch):
+    monkeypatch.delenv("PUBLISH_INTERVAL", raising=False)
+    assert trend_scheduler.publish_interval_minutes() == 60
+
+
+def test_publish_interval_env_override(monkeypatch):
+    monkeypatch.setenv("PUBLISH_INTERVAL", "45")
+    assert trend_scheduler.publish_interval_minutes() == 45


### PR DESCRIPTION
## Summary

- Each `PUBLISH_TIMES` slot fired one job posting all tracked subreddits
  back-to-back — a burst of three posts in ~2 minutes. Now the scheduler
  creates one cron job per (slot, subreddit) with a `PUBLISH_INTERVAL`-minute
  offset (default 60): posts go out 09:00/10:00/11:00 and 21:00/22:00/23:00
  Lisbon instead of two bursts.
- Staggering is scheduler-level (no long sleeps inside a job), so a restart
  mid-slot loses at most the current subreddit. Offsets crossing midnight
  wrap to the next day's wall time.
- `publish_once()` gains an optional `subreddits` list (manual CLI runs are
  unchanged — they still post everything immediately).

## Test plan

- [x] 7 new tests (54 total passing): default stagger layout, custom
  interval, midnight wrap, `PUBLISH_INTERVAL` env parsing, and
  `publish_once` limited/default subreddit selection
- [x] `ruff check .` clean
- [x] Live run with the production env: scheduler logs six jobs at
  09/10/11 + 21/22/23 Europe/Lisbon, clean SIGTERM shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)