### PR TITLE
Document how to obtain Reddit OAuth credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Added
 - README section "Getting Reddit OAuth credentials": link to
-  reddit.com/prefs/apps, the redirect uri to register and the
-  `tools/1_get_refresh_token.py --save` step (`docs/reddit-oauth-credentials`).
+  reddit.com/prefs/apps, the redirect uri to register, the `.env` variables,
+  the `tools/1_get_refresh_token.py --save` step and what it does with the
+  authorize / access_token endpoints (`docs/reddit-oauth-credentials`).
 - `.github/FUNDING.yml` with GitHub Sponsors, Buy Me a Coffee and Patreon links
   (`chore/funding`).
 - Configurable publish timezone: `PUBLISH_TIMES` slots are now interpreted in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 ### Added
+- README section "Getting Reddit OAuth credentials": link to
+  reddit.com/prefs/apps, the redirect uri to register and the
+  `tools/1_get_refresh_token.py --save` step (`docs/reddit-oauth-credentials`).
 - `.github/FUNDING.yml` with GitHub Sponsors, Buy Me a Coffee and Patreon links
   (`chore/funding`).
 - Configurable publish timezone: `PUBLISH_TIMES` slots are now interpreted in

--- a/README.md
+++ b/README.md
@@ -67,12 +67,31 @@ Add these to your `.env` (see `env.example`):
 
 ### Getting Reddit OAuth credentials
 
-1. Create an app at [reddit.com/prefs/apps](https://www.reddit.com/prefs/apps)
-   (type: **web app**, redirect uri: `http://127.0.0.1:8000`).
-2. Put `REDDIT_CLIENT_ID`, `REDDIT_CLIENT_SECRET`, `REDDIT_USER_AGENT` and
-   `REDIRECT_PORT=8000` in `.env`.
-3. Run `python tools/1_get_refresh_token.py --save` and approve access in the
-   browser — `REDDIT_REFRESH_TOKEN` is saved to `.env`.
+A regular app on your own Reddit account plus a refresh token from the OAuth2
+authorization code flow.
+
+1. Create an app at https://www.reddit.com/prefs/apps
+   - type: **web app**
+   - redirect uri: `http://127.0.0.1:8000`
+2. Add to `.env`:
+   ```
+   REDDIT_CLIENT_ID=<app id>
+   REDDIT_CLIENT_SECRET=<app secret>
+   REDDIT_USER_AGENT=<your User-Agent>
+   REDIRECT_PORT=8000
+   ```
+3. Run the script
+   ([`tools/1_get_refresh_token.py`](https://github.com/yumiaura/RedditSync/blob/main/tools/1_get_refresh_token.py)):
+   ```bash
+   python tools/1_get_refresh_token.py --save
+   ```
+   It opens the authorization page https://www.reddit.com/api/v1/authorize
+   (scope: `read`, duration: `permanent`) in the browser, catches the code on
+   `http://127.0.0.1:8000`, exchanges it for tokens at
+   https://www.reddit.com/api/v1/access_token and saves `REDDIT_REFRESH_TOKEN`
+   to `.env`.
+4. From then on the publisher mints a short-lived access token from the
+   refresh token by itself and reads listings through https://oauth.reddit.com
 
 ### Running
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ Add these to your `.env` (see `env.example`):
 | `PUBLISH_INTERVAL` | Minutes between subreddits within a slot | `60` |
 | `PUBLISHED_DB` | Path to the dedup SQLite store | `./data/published.sqlite` |
 
+### Getting Reddit OAuth credentials
+
+1. Create an app at [reddit.com/prefs/apps](https://www.reddit.com/prefs/apps)
+   (type: **web app**, redirect uri: `http://127.0.0.1:8000`).
+2. Put `REDDIT_CLIENT_ID`, `REDDIT_CLIENT_SECRET`, `REDDIT_USER_AGENT` and
+   `REDIRECT_PORT=8000` in `.env`.
+3. Run `python tools/1_get_refresh_token.py --save` and approve access in the
+   browser — `REDDIT_REFRESH_TOKEN` is saved to `.env`.
+
 ### Running
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a **Getting Reddit OAuth credentials** section to the README: a link to [reddit.com/prefs/apps](https://www.reddit.com/prefs/apps), the app type and redirect uri (`http://127.0.0.1:8000`), the `.env` variables, and the `tools/1_get_refresh_token.py --save` step.
- CHANGELOG entry under *Unreleased / Added* (`docs/reddit-oauth-credentials`).

Refs #14

## Test plan
- [ ] README renders correctly on GitHub; the prefs/apps link opens
- [ ] Steps match `tools/1_get_refresh_token.py` (`REDIRECT_PORT`, `--save`)
