### PR TITLE
Fix the web UI post page crash and missing score/comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
   job (`feat/staggered-publish`).
 
 ### Fixed
+- Web UI: the post page no longer crashes with "'moment' is undefined" — the
+  template called a `moment()` helper that was never defined; `created_utc`
+  (a unix timestamp) is now converted to a UTC datetime in the route and
+  formatted with `strftime`. The list and post pages now receive `score` and
+  `comment_count`, so they stop showing "0 points" / "0 comments" for every
+  post (`fix/web-ui-templates`).
 - Trend auto-publisher reads Reddit through the OAuth API
   (`oauth.reddit.com`) instead of old.reddit's Atom feeds and HTML listings
   (`fix/reddit-oauth-listings`). Reddit closed the anonymous routes: old.reddit

--- a/web/app.py
+++ b/web/app.py
@@ -4,6 +4,7 @@ This module provides a web interface for browsing downloaded Reddit content.
 Uses SQLAlchemy ORM for database operations and supports various media types.
 """
 import asyncio
+from datetime import datetime, timezone
 import io
 import logging
 import os
@@ -75,7 +76,9 @@ def index():
                     'media_uid': item.media_uid,
                     'author': item.author,
                     'added_at': item.added_at,
-                    'thread_id': item.thread_id
+                    'thread_id': item.thread_id,
+                    'score': item.score,
+                    'comment_count': item.comment_count
                 }
                 for item in news_items
             ]
@@ -103,9 +106,15 @@ def news_detail(news_id):
                     'external_id': item.external_id,
                     'media_uid': item.media_uid,
                     'media_url': item.media_url,
-                    'created_utc': item.created_utc,
+                    # created_utc is stored as a unix timestamp
+                    'created_utc': (
+                        datetime.fromtimestamp(item.created_utc, timezone.utc)
+                        if item.created_utc else None
+                    ),
                     'added_at': item.added_at,
                     'thread_id': item.thread_id,
+                    'score': item.score,
+                    'comment_count': item.comment_count,
                     'raw_json': item.raw_json
                 }
             return None

--- a/web/templates/detail.html
+++ b/web/templates/detail.html
@@ -41,7 +41,7 @@
             <div><strong>Comments:</strong> {{ item['comment_count'] or 0 }}</div>
             <div><strong>Posted:</strong> 
                 {% if item['created_utc'] %}
-                    {{ moment(item['created_utc']).format('YYYY-MM-DD HH:mm:ss') }}
+                    {{ item['created_utc'].strftime('%Y-%m-%d %H:%M:%S') }}
                 {% else %}
                     Unknown
                 {% endif %}


### PR DESCRIPTION
## Summary
- **Post page crash:** `detail.html` called a `moment()` helper that is not defined anywhere, so any post with a `created_utc` failed with `jinja2.exceptions.UndefinedError: 'moment' is undefined` (HTTP 500). The route now converts `created_utc` (a unix timestamp) to a UTC datetime and the template formats it with `strftime`, like `added_at`.
- **Score / comments always 0:** both pages print `score` and `comment_count`, but the `/` and `/news/<id>` routes never passed them. They do now.
- CHANGELOG entry under *Unreleased / Fixed* (`fix/web-ui-templates`).

## Test plan
- [x] Seeded a temp DB (one post with date/score 742/31 comments, one without) and rendered `/` and `/news/<id>` via the Flask test client: 200, `742 points`, `31` comments, `Posted: 2025-09-10 16:00:00`; the post without a date shows `Unknown`
- [x] Same check against `main` reproduces both bugs (`'moment' is undefined`, all scores `0`)
- [x] `ruff check .` passes
- [x] CI green
